### PR TITLE
Use HEAD requests to check for video existence

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ synctube.qswitcher = class {
     let promises = videoUrls
       //.map(url => `https://cors-anywhere.herokuapp.com/${encodeURI(url)}`)
       .map(url => `/proxy?url=${encodeURI(url)}`)
-      .map(url => fetch(url, {redirect: 'manual'}));
+      .map(url => fetch(url, {method: 'HEAD', redirect: 'manual'}));
     Promise.all(promises)
       .then(responses => {
         // For all requests, take only successfull 


### PR DESCRIPTION
Currently, all found videos are downloaded fully in the background while the selected video is playing, which completely defeats the point of using this plugin (reducing bandwidth).